### PR TITLE
jsonata expression evaluation is async, so needs to be awaited

### DIFF
--- a/json-multi-schema-resolver.js
+++ b/json-multi-schema-resolver.js
@@ -28,7 +28,7 @@ module.exports = RED => {
 			for (const mapping of mappings) {
 				if (mapping.query && mapping.cases) {
 					const expression = jsonata(mapping.query);
-					let match = expression.evaluate(payload);
+					let match = await expression.evaluate(payload);
 					if (match) {
 						if (match === true) {
 							// Special case for boolean

--- a/json-multi-schema-transformer.js
+++ b/json-multi-schema-transformer.js
@@ -54,7 +54,7 @@ module.exports = RED => {
 
 			if (jsonataExpression) {
 				// Perform transformation
-				return jsonataExpression.evaluate(payload);
+				return await jsonataExpression.evaluate(payload);
 			}
 
 			return false;


### PR DESCRIPTION
https://github.com/jsonata-js/jsonata/blob/master/CHANGELOG.md#200-major-release

It looks like version 2.0 of the `jsonata` package changed `expression.evaluate` to return a promise, so the `match` object was never matching an actual case from `cases`. You can see the change they made in their quick start docs here: https://github.com/jsonata-js/jsonata#quick-start

I haven't checked the rest of this codebase for any other problems like this, as I am only using the resolver with JSOnata and validator nodes with JSON Schema.